### PR TITLE
feat(web): add Dashboard home tab

### DIFF
--- a/.github/workflows/build-web.yaml
+++ b/.github/workflows/build-web.yaml
@@ -28,9 +28,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-      # No lockfile yet — use `npm install`. Switch to `npm ci` once a
-      # package-lock.json is committed.
-      - run: npm install --no-audit --no-fund
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - run: npm ci --no-audit --no-fund
         working-directory: web
       - run: npm run build
         working-directory: web

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,9 +41,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-      # No lockfile yet — use `npm install`. Switch to `npm ci` once a
-      # package-lock.json is committed.
-      - run: npm install --no-audit --no-fund
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - run: npm ci --no-audit --no-fund
         working-directory: web
       - run: npm run build
         working-directory: web

--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+npm-debug.log*
+.DS_Store

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -4,11 +4,11 @@ FROM node:18-alpine AS build
 # Set the working directory in the container
 WORKDIR /app
 
-# Copy package.json and package-lock.json (if available)
-COPY package.json ./
+# Copy the manifest + lockfile first so the install layer caches on deps alone
+COPY package.json package-lock.json ./
 
-# Install dependencies
-RUN npm install
+# Install exactly what the lockfile pins (reproducible; fails on drift)
+RUN npm ci --no-audit --no-fund
 
 # Copy the rest of the application code
 COPY . .

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,0 +1,1177 @@
+{
+  "name": "chartpress-web",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "chartpress-web",
+      "version": "1.0.0",
+      "dependencies": {
+        "react": "18.0.0",
+        "react-dom": "18.0.0"
+      },
+      "devDependencies": {
+        "@babel/runtime": "7.13.8",
+        "@types/react": "^18.0.28",
+        "@types/react-dom": "^18.0.11",
+        "@vitejs/plugin-react": "^3.1.0",
+        "typescript": "^4.9.3",
+        "vite": "^4.5.5"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.13.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.18.20",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.31",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.20.12",
+        "@babel/plugin-transform-react-jsx-self": "^7.18.6",
+        "@babel/plugin-transform-react-jsx-source": "^7.19.6",
+        "magic-string": "^0.27.0",
+        "react-refresh": "^0.14.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.1.0-beta.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.40",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.4",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001799",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.381",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.18.20",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.18.20",
+        "@esbuild/android-arm64": "0.18.20",
+        "@esbuild/android-x64": "0.18.20",
+        "@esbuild/darwin-arm64": "0.18.20",
+        "@esbuild/darwin-x64": "0.18.20",
+        "@esbuild/freebsd-arm64": "0.18.20",
+        "@esbuild/freebsd-x64": "0.18.20",
+        "@esbuild/linux-arm": "0.18.20",
+        "@esbuild/linux-arm64": "0.18.20",
+        "@esbuild/linux-ia32": "0.18.20",
+        "@esbuild/linux-loong64": "0.18.20",
+        "@esbuild/linux-mips64el": "0.18.20",
+        "@esbuild/linux-ppc64": "0.18.20",
+        "@esbuild/linux-riscv64": "0.18.20",
+        "@esbuild/linux-s390x": "0.18.20",
+        "@esbuild/linux-x64": "0.18.20",
+        "@esbuild/netbsd-x64": "0.18.20",
+        "@esbuild/openbsd-x64": "0.18.20",
+        "@esbuild/sunos-x64": "0.18.20",
+        "@esbuild/win32-arm64": "0.18.20",
+        "@esbuild/win32-ia32": "0.18.20",
+        "@esbuild/win32-x64": "0.18.20"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.27.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.13"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.50",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.21.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.14.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "3.30.0",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=14.18.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.21.0",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.9.5",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "4.5.14",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.18.10",
+        "postcss": "^8.4.27",
+        "rollup": "^3.27.1"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@types/node": ">= 14",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,7 @@
     "@types/react-dom": "^18.0.11",
     "@vitejs/plugin-react": "^3.1.0",
     "typescript": "^4.9.3",
-    "vite": "^7.1.5"
+    "vite": "^4.5.5"
   },
   "scripts": {
     "dev": "vite",

--- a/web/src/app/AppShell.jsx
+++ b/web/src/app/AppShell.jsx
@@ -9,6 +9,7 @@
 // whether it's configured and who (if anyone) is signed in — the app is fully
 // usable signed-out.
 import React from "react";
+import { DashboardScreen } from "./DashboardScreen.jsx";
 import { ChooseScreen } from "./ChooseScreen.jsx";
 import { PromptScreen } from "./PromptScreen.jsx";
 import { ComposeScreen } from "./ComposeScreen.jsx";
@@ -32,7 +33,7 @@ function sortCharts(list) {
 }
 
 export function AppShell() {
-  const [nav, setNav] = React.useState("charts"); // generate | charts | profile | explorer
+  const [nav, setNav] = React.useState("dashboard"); // dashboard | generate | charts | profile | explorer
   const [step, setStep] = React.useState("choose"); // choose | prompt | compose | form
   const [draftSpec, setDraftSpec] = React.useState(null);
   const [draftFrom, setDraftFrom] = React.useState("choose"); // which step the form's Back returns to
@@ -107,6 +108,7 @@ export function AppShell() {
     }
   };
 
+  const goDashboard = () => { setNav("dashboard"); setOpenChart(null); };
   const goGenerate = () => { setNav("generate"); setStep("choose"); setDraftSpec(null); setDraftFrom("choose"); setOpenChart(null); };
   const goCharts = () => { setNav("charts"); setOpenChart(null); refreshCharts(); };
   const openChartView = (chart) => { setOpenChart(chart); setNav("explorer"); };
@@ -140,6 +142,7 @@ export function AppShell() {
             </span>
           </div>
           <div style={{ display: "flex", gap: 4 }}>
+            <NavLink active={nav === "dashboard"} onClick={goDashboard}>Dashboard</NavLink>
             <NavLink active={nav === "generate"} onClick={goGenerate}>Generate</NavLink>
             <NavLink active={nav === "charts" || nav === "explorer"} onClick={goCharts}>Charts</NavLink>
           </div>
@@ -159,6 +162,15 @@ export function AppShell() {
         </main>
       ) : (
         <main style={{ padding: "40px 28px 72px" }}>
+          {nav === "dashboard" && (
+            <DashboardScreen
+              user={displayUser}
+              charts={charts}
+              onGenerate={goGenerate}
+              onBrowse={goCharts}
+              onOpenChart={openChartView}
+            />
+          )}
           {nav === "profile" && displayUser && (
             <ProfileScreen user={displayUser} charts={charts} onBack={() => setNav("charts")} />
           )}

--- a/web/src/app/DashboardScreen.jsx
+++ b/web/src/app/DashboardScreen.jsx
@@ -1,0 +1,230 @@
+// Dashboard — the home tab (alongside Generate and Charts). It doesn't collect
+// input; it orients you: what chartpress does (scaffold a chart + emit a per-
+// subchart HANDOFF prompt you pair with your real code), a peek at that prompt,
+// the catalog of subchart patterns it knows, and your recent charts.
+import React from "react";
+import { Card, Button, StatusBadge, Badge } from "../design/components";
+import { Plus, ArrowRight, Package, Sparkle, Layers } from "./Icons.jsx";
+import { PATTERNS } from "./spec.js";
+
+// A faithful excerpt of the HANDOFF.md chartpress writes per subchart. The
+// checklist mirrors the api-microservice pattern's finishing steps (patterns.json).
+const HANDOFF = [
+  { t: "c", s: "# HANDOFF — ledger-api  (pattern: api-microservice)" },
+  { t: "b" },
+  { t: "p", s: "Finish this Helm chart scaffold against the service's real code." },
+  { t: "p", s: "Edit values.yaml and templates/ to match what the app actually does." },
+  { t: "b" },
+  { t: "todo", s: "Find the port the app listens on (code / Dockerfile EXPOSE) → service.port" },
+  { t: "todo", s: "Wire real liveness & readiness probes; readiness may check deps" },
+  { t: "todo", s: "Map env vars: shared config vs. this chart's own Secret" },
+  { t: "todo", s: "Measure shutdown drain time → terminationGracePeriodSeconds" },
+  { t: "todo", s: "Size resources.requests and the memory limit from expected load" },
+];
+const HANDOFF_TEXT = HANDOFF.map((l) => (l.t === "b" ? "" : l.t === "todo" ? `- [ ] ${l.s}` : l.s)).join("\n");
+
+export function DashboardScreen({ user, charts = [], onGenerate, onOpenChart, onBrowse }) {
+  const recents = charts.slice(0, 4);
+
+  return (
+    <div style={{ maxWidth: 760, margin: "0 auto" }}>
+      <p style={{ margin: "0 0 6px", fontSize: 13, color: "var(--text-muted)" }}>
+        {user ? `Welcome back, ${user.name}` : "chartpress"}
+      </p>
+      <h1 style={{ margin: "0 0 22px", fontSize: 27, fontWeight: 700, letterSpacing: "-0.02em", color: "var(--text-1)" }}>
+        What are you <span style={{ color: "var(--accent-9)" }}>deploying</span>?
+      </h1>
+
+      <Card padding={0} elevation={2} style={{ overflow: "hidden" }}>
+        <div style={{ padding: 24 }}>
+          <p style={{ margin: 0, fontSize: 15, lineHeight: 1.6, color: "var(--text-1)" }}>
+            <b style={{ fontWeight: 600 }}>chartpress</b> is a Helm chart scaffolding tool. Describe the
+            services your app is made of and it generates a complete umbrella chart and one subchart per
+            service — plus a matching <b style={{ fontWeight: 600 }}>LLM prompt</b> for each. Pair that prompt
+            with the code you actually want to ship, and an agent (or you) finishes the chart against what
+            the app really does.
+          </p>
+
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12, marginTop: 20 }}>
+            <Step
+              n="1" icon={<Package size={16} />} title="Scaffold"
+              body="You name the services; chartpress writes the umbrella chart, a subchart for each, wires dependencies, and applies your rules."
+            />
+            <Step
+              n="2" icon={<Sparkle size={16} />} title="Hand off to an LLM"
+              body="Every subchart ships a HANDOFF checklist. Give it to an agent with your app code — it resolves ports, probes, env, and resources."
+            />
+          </div>
+        </div>
+
+        {/* A peek at the generated prompt */}
+        <div style={{ padding: "0 24px 20px" }}>
+          <div style={snippetWrap}>
+            <div style={snippetBar}>
+              <span style={{ display: "inline-flex", alignItems: "center", gap: 7, color: "var(--text-on-code)", opacity: 0.85, fontSize: 12, fontFamily: "var(--font-mono)" }}>
+                <FileGlyph /> HANDOFF.md
+              </span>
+              <CopyButton text={HANDOFF_TEXT} />
+            </div>
+            <pre style={snippetPre}>
+              {HANDOFF.map((l, i) => <Line key={i} line={l} />)}
+            </pre>
+          </div>
+        </div>
+
+        {/* Subchart pattern catalog */}
+        <div style={{ padding: "0 24px 22px" }}>
+          <div style={sectionLabel}>
+            <Layers size={13} /> Subchart patterns it knows
+            <Badge color="neutral" variant="soft" size="1" style={{ marginLeft: 2 }}>{PATTERNS.length}</Badge>
+          </div>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+            {PATTERNS.map((p) => <Pill key={p.id} label={p.label} />)}
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div style={ctaRow}>
+          <Button size="3" leadingIcon={<Plus size={16} />} onClick={onGenerate}>Generate a chart</Button>
+          <Button size="3" variant="soft" trailingIcon={<ArrowRight size={16} />} onClick={onBrowse}>Browse your charts</Button>
+        </div>
+      </Card>
+
+      {recents.length > 0 && (
+        <div style={{ marginTop: 34 }}>
+          <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between", marginBottom: 10 }}>
+            <h2 style={{ margin: 0, fontSize: 13, fontWeight: 600, color: "var(--text-1)" }}>Pick up where you left off</h2>
+            <button onClick={onBrowse} style={linkBtn}>All charts →</button>
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            {recents.map((c, i) => <RecentRow key={c.name + i} chart={c} onOpen={onOpenChart} />)}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Step({ n, icon, title, body }) {
+  return (
+    <div style={{ background: "var(--surface-sunken)", border: "1px solid var(--border-subtle)", borderRadius: "var(--radius-4)", padding: "13px 14px" }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6 }}>
+        <span style={{ width: 24, height: 24, borderRadius: "50%", background: "var(--accent-3)", color: "var(--accent-11)", display: "grid", placeItems: "center", flexShrink: 0 }}>{icon}</span>
+        <span style={{ fontSize: 13.5, fontWeight: 600, color: "var(--text-1)" }}>{title}</span>
+        <span style={{ marginLeft: "auto", fontSize: 11, fontWeight: 600, color: "var(--text-muted)", fontVariantNumeric: "tabular-nums" }}>{n}</span>
+      </div>
+      <p style={{ margin: 0, fontSize: 12.5, lineHeight: 1.5, color: "var(--text-2)" }}>{body}</p>
+    </div>
+  );
+}
+
+function Pill({ label }) {
+  return (
+    <span style={{
+      fontSize: 12.5, fontFamily: "var(--font-mono)", color: "var(--text-2)",
+      background: "var(--surface-card)", border: "1px solid var(--border-default)",
+      borderRadius: "var(--radius-full)", padding: "4px 11px", whiteSpace: "nowrap",
+    }}>{label}</span>
+  );
+}
+
+function Line({ line }) {
+  if (line.t === "b") return <div style={{ height: "1.55em" }} />;
+  if (line.t === "c") return <div style={{ color: "#7bd88f" }}>{line.s}</div>;
+  if (line.t === "p") return <div style={{ color: "#9a9ab5" }}>{line.s}</div>;
+  return (
+    <div style={{ color: "var(--text-on-code)" }}>
+      <span style={{ color: "#8fb3ff" }}>- [ ] </span>{line.s}
+    </div>
+  );
+}
+
+function CopyButton({ text }) {
+  const [copied, setCopied] = React.useState(false);
+  const copy = () => {
+    try {
+      navigator.clipboard?.writeText(text).then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1400);
+      });
+    } catch { /* clipboard unavailable — ignore */ }
+  };
+  return (
+    <button onClick={copy} style={copyBtn}>
+      {copied ? "Copied" : "Copy"}
+    </button>
+  );
+}
+
+function RecentRow({ chart, onOpen }) {
+  const [hover, setHover] = React.useState(false);
+  return (
+    <button
+      onClick={() => onOpen?.(chart)}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      style={{
+        display: "flex", alignItems: "center", gap: 12, textAlign: "left", width: "100%",
+        padding: "11px 14px", background: "var(--surface-card)", cursor: "pointer",
+        border: "1px solid " + (hover ? "var(--slate-7)" : "var(--border-default)"),
+        borderRadius: "var(--radius-4)", boxShadow: hover ? "var(--shadow-2)" : "none",
+        transition: "box-shadow .12s, border-color .12s",
+      }}
+    >
+      <span style={{ fontFamily: "var(--font-mono)", fontWeight: 500, fontSize: 13.5, color: "var(--text-1)", flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+        {chart.name}
+      </span>
+      <span style={{ fontSize: 12, color: "var(--text-muted)", whiteSpace: "nowrap" }}>
+        {chart.subchartCount != null ? `${chart.subchartCount} subchart${chart.subchartCount === 1 ? "" : "s"}` : ""}
+        {chart.lastGenerated ? ` · ${timeAgo(chart.lastGenerated)}` : ""}
+      </span>
+      <StatusBadge phase={chart.phase} size="1" />
+    </button>
+  );
+}
+
+function timeAgo(ts) {
+  if (!ts) return "";
+  const d = new Date(ts);
+  if (isNaN(d)) return String(ts);
+  const diff = (Date.now() - d.getTime()) / 1000;
+  if (diff < 60) return "just now";
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+function FileGlyph() {
+  return <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"><path d="M14 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8l-5-5Z" /><path d="M14 3v5h5" /></svg>;
+}
+
+const snippetWrap = {
+  background: "var(--surface-code)", borderRadius: "var(--radius-code)", overflow: "hidden",
+  border: "1px solid rgba(255,255,255,0.06)",
+};
+const snippetBar = {
+  display: "flex", alignItems: "center", justifyContent: "space-between",
+  padding: "8px 12px", borderBottom: "1px solid rgba(255,255,255,0.07)",
+};
+const snippetPre = {
+  margin: 0, padding: "12px 14px", fontFamily: "var(--font-mono)", fontSize: 12.5,
+  lineHeight: "var(--line-height-code)", color: "var(--text-on-code)",
+  whiteSpace: "pre-wrap", wordBreak: "break-word", overflowX: "auto",
+};
+const copyBtn = {
+  background: "rgba(255,255,255,0.08)", color: "var(--text-on-code)", border: "none",
+  borderRadius: "var(--radius-2)", padding: "3px 9px", fontSize: 11.5, fontWeight: 600,
+  fontFamily: "var(--font-sans)", cursor: "pointer",
+};
+const sectionLabel = {
+  display: "flex", alignItems: "center", gap: 7, marginBottom: 10,
+  fontSize: 12, fontWeight: 600, color: "var(--text-muted)",
+};
+const ctaRow = {
+  display: "flex", gap: 10, flexWrap: "wrap", padding: "18px 24px",
+  borderTop: "1px solid var(--border-subtle)", background: "var(--surface-sunken)",
+};
+const linkBtn = {
+  background: "transparent", border: "none", color: "var(--text-accent)",
+  fontSize: 13, fontWeight: 500, cursor: "pointer", fontFamily: "var(--font-sans)", padding: 0,
+};

--- a/web/src/app/DashboardScreen.jsx
+++ b/web/src/app/DashboardScreen.jsx
@@ -97,7 +97,7 @@ export function DashboardScreen({ user, charts = [], onGenerate, onOpenChart, on
             <button onClick={onBrowse} style={linkBtn}>All charts →</button>
           </div>
           <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-            {recents.map((c, i) => <RecentRow key={c.name + i} chart={c} onOpen={onOpenChart} />)}
+            {recents.map((c, i) => <RecentRow key={c.name + i} chart={c} onOpen={onOpenChart} onBrowse={onBrowse} />)}
           </div>
         </div>
       )}
@@ -156,11 +156,17 @@ function CopyButton({ text }) {
   );
 }
 
-function RecentRow({ chart, onOpen }) {
+function RecentRow({ chart, onOpen, onBrowse }) {
   const [hover, setHover] = React.useState(false);
+  // The explorer's file fetch 409s until a chart is Ready, and this row is a stale
+  // snapshot that won't re-poll — so only open Ready/Failed charts directly. Send a
+  // still-building chart to the Charts list, where polling shows it advance.
+  const phase = String(chart.phase || "").toLowerCase();
+  const openable = phase === "ready" || phase === "failed";
+  const handleClick = () => (openable ? onOpen?.(chart) : onBrowse?.());
   return (
     <button
-      onClick={() => onOpen?.(chart)}
+      onClick={handleClick}
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}
       style={{


### PR DESCRIPTION
## What

Adds a **Dashboard** tab to the web app, alongside Generate and Charts (not replacing either), and makes it the default landing page.

Unlike Generate, the Dashboard doesn't collect input — it **orients you**:

- Explains what chartpress does: scaffolds an umbrella chart + one subchart per service, *plus a per-subchart `HANDOFF` prompt* you pair with your real code so an agent (or you) finishes the chart against what the app actually does.
- A two-step **Scaffold → Hand off to an LLM** flow.
- A **`HANDOFF.md` snippet** (dark code block with a Copy button) whose checklist mirrors the `api-microservice` pattern's finishing steps.
- The **subchart pattern catalog** as pills, sourced from `PATTERNS` in `spec.js` so it stays in sync with the engine (13 patterns).
- A **"Pick up where you left off"** recents list that appears when charts exist.

## Changes

- `web/src/app/DashboardScreen.jsx` — new screen.
- `web/src/app/AppShell.jsx` — `Dashboard | Generate | Charts` nav (Dashboard first + default), `goDashboard` handler, render branch wired to `goGenerate` / `goCharts` / `openChartView`.

## How it routes

- **Generate a chart** → Generate wizard (`ChooseScreen`)
- **Browse your charts** / **All charts →** → Charts
- **Dashboard** tab → home

## Testing

Ran the Vite dev app: compiles with no console errors; nav renders `Dashboard | Generate | Charts`; the explainer, HANDOFF snippet, all 13 pattern pills, and both CTAs render; routing verified (CTA → wizard, Browse → Charts, tab → home). Backend wasn't running, so recents and the signed-in name are empty as expected — both populate against a live `chartpress-server`.

## Notes

- Reuses the existing design system (tokens, `Card`/`Button`/`Badge`/`StatusBadge`, `Icons.jsx`) — no new deps.
- Follow-up idea left out to keep scope tight: a ⌘K command palette on the Dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)